### PR TITLE
GodOfWar.asl

### DIFF
--- a/GodOfWar.asl
+++ b/GodOfWar.asl
@@ -6,9 +6,10 @@ state("GoW")
     int Load : 0x22E9DB0; //0 not loading; 257/256 loading
     int Shop : 0x2448448; //0 out of the shop; 2 in the shop
     int Valk : 0x2D43714; //36628 = 0 valks; 38192 all valks
-    int SkapSlag : 0x0142B1E0, 0x0, 0x28, 0x20, 0x0, 0x40, 0x17B0; //tracks current Skap Slag
+    int SkapSlag : 0x0142C400, 0x0, 0x28, 0x20, 0x0, 0x40, 0x17B0; //tracks current Skap Slag
     string5 MRT : 0x01580010, 0x2A8, 0x0; //Tracks the number of odin ravens destroyed in midgard
     int ORL : 0x01425F90, 0x9AC0; //Tracks the number for the labor of odins ravens
+    int MainMenu : 0x22E9DB4; //1 When in the main menu an when selecting the difficulty and 0 when your not in either of those situations
 
     //address for all the helmets of the Valks a lot easier than having the obj number
     int GunnrHelmet : 0x014261C0, 0x230; //-1 when u dont have the helmet 1 when u do then 0 if u plcae it on the council of the valks
@@ -22,6 +23,7 @@ state("GoW")
     int SigrunHelmet : 0x014261C0, 0x430; // -1 when u dont have the helmet 1 when u do
 }
 
+
 startup
 {
     settings.Add("Split for Main Game", true);
@@ -30,14 +32,14 @@ startup
     settings.SetToolTip("Split for Valkyrie%", "Splits whenever you gain one of the Valkyrie's helmets");
     settings.Add("100% NG+", false);
     settings.SetToolTip("100% NG+", "Enable this for the other option bellow. IMPORTANT! the stuff bellow is follows TpRedNinja's 100% splits and route so might not line up with your splits");
-    settings.Add("Main Story", true, "Main Story splits", "100% NG+");
+    settings.Add("Main Story", false, "Main Story splits", "100% NG+");
     settings.SetToolTip("Main Story", "Splits for certain mainstory stuff such as 1st troll fight, completeing the story portion of alfheim, & some other place");
-    settings.Add("Valks", true, "Valkyrie splits", "100% NG+");
+    settings.Add("Valks", false, "Valkyrie splits", "100% NG+");
     settings.SetToolTip("Valks", "Splits whenever you gain one of the Valkyrie's helmets");
-    settings.Add("Side Stuff", true, "Collectible splits", "100% NG+");
+    settings.Add("Side Stuff", false, "Collectible splits", "100% NG+");
     settings.SetToolTip("Side Stuff", "Splits whenever you gain 5, 9, or 18 skap slag such as certain obj, realm tears completion, completing labors/artifact sets, & unlocking a new realm");
-    settings.Add("Locations", true, "Location splits", "100% NG+");
-    settings.SetToolTip("Locations", "Splits when you leave Stone falls after first visit and second visit, Brui storeroom, isle of death, iron cove, when you are at the foothills going into the valkyrie area, after atreus kills modi, then finally when you do the final clumb to the peak for the second time around");
+    settings.Add("Locations", false, "Location splits", "100% NG+");
+    settings.SetToolTip("Locations", "Splits when you leave Stone falls after first visit and second visit, isle of death, iron cove,foothills going valk area , after atreus kills modi, final climb up the peak 2nd time");
     vars.completedsplits = new List<string>();
     vars.Hundo = new List<string>();
 }
@@ -124,10 +126,14 @@ init
 
 start
 {
-    if (settings["Split for Main Game"] && current.Obj == 0 && old.Obj != 0){
+    if (settings["Split for Main Game"] && current.MainMenu == 0 && old.MainMenu == 1 && current.Load == 0){
         return true;
     }
     if (settings["Split for Valkyrie%"] && old.Shop > current.Shop){
+        return true;
+    }
+    if (settings["100% NG+"] && current.MainMenu == 0 && old.MainMenu == 1 && current.Load == 0)
+    {
         return true;
     }
 }
@@ -175,125 +181,122 @@ split
         return true;
     }
 
-    //splits whenever skapslag increases by 5, 9, or 18
-    if (settings["Side Stuff"] && (current.SkapSlag == old.SkapSlag + 5 || current.SkapSlag == old.SkapSlag + 9 || current.SkapSlag == old.SkapSlag + 18))
+   //makes sure it doesnt split when placing the valk helmets also splits when skap slag increases by 5,9, or 18
+    if (settings["Side Stuff"] && current.SkapSlag == old.SkapSlag + 9 && (current.GunnrHelmet == 0 || current.KaraHelmet == 0 || current.GeirdrifulHelmet == 0 || current.EirHelmet == 0 || current.RòtaHelmet == 0 || current.OlrunHelmet == 0 || current.GöndulHelmet == 0 || current.HildrHelmet == 0))
+    {
+        return false;
+    } else if (settings["Valks"] && !vars.completedsplits.Contains("Hildur") && current.SkapSlag == old.SkapSlag + 9 && vars.completedsplits.Contains("Göndul") && current.Göndul)
+    {
+        vars.completedsplits.Add("Hildur");
+        return true;
+    } else if (settings["Side Stuff"] && (current.SkapSlag == old.SkapSlag + 5 || current.SkapSlag == old.SkapSlag + 9 || current.SkapSlag == old.SkapSlag + 18) )
     {
         vars.completedsplits.Add(vars.Hundo[0]);
         vars.Hundo.RemoveAt(0);
         return true;
-    } else if (settings["Side Stuff"] && current.SkapSlag == old.SkapSlag + 9 && (current.GunnrHelmet == 0 || current.KaraHelmet == 0 || current.GeirdrifulHelmet == 0 || current.EirHelmet == 0 || current.RòtaHelmet == 0 || current.OlrunHelmet == 0 || current.GöndulHelmet == 0 || current.HildrHelmet == 0))
-    {
-        return false;
-    } else if (settings["Side Stuff"] && current.SkapSlag == old.SkapSlag + 9 && current.ORL == 51 && current.Obj == 3568 && current.MRT != "43/43" )
-    {
-        return false;
-    }
-   
-    if (settings["Locations"] && current.SaveDescript == "Midgard - Shores of Nine - Return to the Witch's Cave" && old.SaveDescript == "Midgard - Stone Falls - Return to the Witch's Cave")
-    {
-        vars.completedsplits.inserts(0, "Stone Falls I");
-        return true;
-    } else if (settings["Locations"] && current.SaveDescript == "Midgard - Iron Cove - Return to Týr’s Vault" && old.SaveDescript == "Midgard - Isle of Death - Return to Týr’s Vault")
-    {
-        vars.completedsplits.inserts(0, "Isle of Death");
-        return true;
-    } else if (settings["Locations"] && current.SaveDescript == "Midgard - Shores of Nine - Return to Týr’s Vault" && old.SaveDescript == "Midgard - Iron Cove - Return to Týr’s Vault")
-    {
-        vars.completedsplits.inserts(0, "Iron Cove");
-        return true;
-    } else if (settings["Locations"] && current.SaveDescript == "Midgard - Shores of Nine - Return to Týr’s Vault" && old.SaveDescript == "Midgard - Stone Falls - Return to Týr’s Vault")
-    {
-        vars.completedsplits.inserts(0, "Stone Falls 100%");
-        return true;
-    } else if (settings["Locations"] && current.SaveDescript == "Midgard - Shores of Nine - Return to Týr’s Vault" && old.SaveDescript == "Midgard - Buri’s Storeroom - Return to Týr’s Vault")
-    {
-        vars.completedsplits.inserts(0, "Buri's Storeroom");
-        return true;
-    } else if (settings["Locations"] && current.SaveDescript == "Midgard - Hidden Chamber of Odin - Journey back to the mountain" && old.SaveDescript == "Midgard - Foothills - Journey back to the mountain")
-    {
-        vars.completedsplits.inserts(0, "Foothills III");
-        return true;
-    } else if (settings["Locations"] && current.SaveDescript == "Midgard - The Mountain - Journey back to the mountain" && old.SaveDescript == "Midgard - Foothills - Journey back to the mountain")
-    {
-        vars.completedsplits.inserts(0, "Foothills 100%");
-        return true;
-    } else if (settings["Locations"] && current.SaveDescript == "Midgard - Hidden Chamber of Odin - Find a new path up to the summit" && old.SaveDescript == "Midgard - The Mountain - Find a new path up to the summit")
-    {
-        vars.completedsplits.inserts(0, "Mountain II");
-        return true;
     } 
+   
+        if (settings["Locations"] && current.SaveDescript == "Midgard - Veithurgard - Return to the Witch’s Cave" && old.SaveDescript == "Midgard - Stone Falls - Return to the Witch’s Cave" && !vars.completedsplits.Contains("Stone Falls I"))
+    {
+        vars.completedsplits.Add("Stone Falls I");
+        return true;
+    } else if (settings["Locations"] && current.SaveDescript == "Midgard - Iron Cove - Return to Týr’s Vault" && old.SaveDescript == "Midgard - Isle of Death - Return to Týr’s Vault" && !vars.completedsplits.Contains("Isle of Death"))
+    {
+        vars.completedsplits.Add("Isle of Death");
+        return true;
+    } else if (settings["Locations"] && current.SaveDescript == "Midgard - Shores of Nine - Return to Týr’s Vault" && old.SaveDescript == "Midgard - Iron Cove - Return to Týr’s Vault" && !vars.completedsplits.Contains("Iron Cove"))
+    {
+        vars.completedsplits.Add("Iron Cove");
+        return true;
+    } else if (settings["Locations"] && current.SaveDescript == "Midgard - Shores of Nine - Return to Týr’s Vault" && old.SaveDescript == "Midgard - Stone Falls - Return to Týr’s Vault" && !vars.completedsplits.Contains("Stone Falls 100%"))
+    {
+        vars.completedsplits.Add("Stone Falls 100%");
+        return true;
+    }else if (settings["Locations"] && current.SaveDescript == "Midgard - Hidden Chamber of Odin - Journey back to the mountain" && old.SaveDescript == "Midgard - Foothills - Journey back to the mountain" && !vars.completedsplits.Contains("Foothills III"))
+    {
+        vars.completedsplits.Add("Foothills III");
+        return true;
+    } else if (settings["Locations"] && current.SaveDescript == "Midgard - The Mountain - Journey back to the mountain" && old.SaveDescript == "Midgard - Foothills - Journey back to the mountain" && !vars.completedsplits.Contains("Foothills 100%"))
+    {
+        vars.completedsplits.Add("Foothills 100%");
+        return true;
+    } else if (settings["Locations"] && current.SaveDescript == "Midgard - Hidden Chamber of Odin - Find a new path up to the summit" && old.SaveDescript == "Midgard - The Mountain - Find a new path up to the summit" && !vars.completedsplits.Contains("Mountain II"))
+    {
+        vars.completedsplits.Add("Mountain II");
+        return true;
+    }
     
-    //Splits whenever you gain helmets
-    if (settings["Valks"] && current.GunnrHelmet == 1 && old.GunnrHelmet != 1)
+        //Splits whenever you gain helmets
+    if (settings["Valks"] && current.GunnrHelmet == 1 && old.GunnrHelmet == -1 && !vars.completedsplits.Contains("Gunnr"))
     {
-        vars.completedsplits.insert(0, "Gunnr");
+        vars.completedsplits.Add("Gunnr");
         return true;
-    } else if (settings["Valks"] && current.KaraHelmet == 1 && old.KaraHelmet != 1)
+    } else if (settings["Valks"] && current.KaraHelmet == 1 && old.KaraHelmet == -1 && !vars.completedsplits.Contains("Kara"))
     {
-        vars.completedsplits.insert(0, "Kara");
+        vars.completedsplits.Add("Kara");
         return true;
-    }  else if (settings["Valks"] && current.GeirdrifulHelmet == 1 && old.GeirdrifulHelmet != 1)
+    }  else if (settings["Valks"] && current.GeirdrifulHelmet == 1 && old.GeirdrifulHelmet == -1 && !vars.completedsplits.Contains("Geirdriful"))
     {
-        vars.completedsplits.insert(0, "Geirdriful");
+        vars.completedsplits.Add("Geirdriful");
         return true;
-    }  else if (settings["Valks"] && current.EirHelmet == 1 && old.EirHelmet != 1)
+    }  else if (settings["Valks"] && current.EirHelmet == 1 && old.EirHelmet == -1 && !vars.completedsplits.Contains("Eir"))
     {
-        vars.completedsplits.insert(0, "Eir");
+        vars.completedsplits.Add("Eir");
         return true;
-    } else if (settings["Valks"] && current.RòtaHelmet == 1 && old.RòtaHelmet != 1)
+    } else if (settings["Valks"] && current.RòtaHelmet == 1 && old.RòtaHelmet == -1 && !vars.completedsplits.Contains("Ròta"))
     {
-        vars.completedsplits.insert(0, "Ròta");
+        vars.completedsplits.Add("Ròta");
         return true;
-    } else if (settings["Valks"] && current.OlrunHelmet == 1 && old.OlrunHelmet != 1)
+    } else if (settings["Valks"] && current.OlrunHelmet == 1 && old.OlrunHelmet == -1 && !vars.completedsplits.Contains("Olrun"))
     {
-        vars.completedsplits.insert(0, "Olrun");
+        vars.completedsplits.Add("Olrun");
         return true;
-    } else if (settings["Valks"] && current.GöndulHelmet == 1 && old.GöndulHelmet != 1)
+    } else if (settings["Valks"] && current.GöndulHelmet == 1 && old.GöndulHelmet == -1 && !vars.completedsplits.Contains("Göndul"))
     {
-        vars.completedsplits.insert(0, "Göndul");
+        vars.completedsplits.Add("Göndul");
         return true;
-    } else if (settings["Valks"] && current.SigrunHelmet == 1 && old.SigrunHelmet != 1)
+    } else if (settings["Valks"] && current.SigrunHelmet == 1 && old.SigrunHelmet == -1 && !vars.completedsplits.Contains("Sigrun"))
     {
-        vars.completedsplits.insert(0, "Sigrun");
+        vars.completedsplits.Add("Sigrun");
         return true;
     }
 
     //Splits during certain story points the inserts should give you a clear idea on where that would be
     if (settings["Main Story"] && current.Obj == 678 && old.Obj == 4620)
     {
-        vars.completedsplits.insert(0, "Troll Fight");
+        vars.completedsplits.Add("Troll Fight");
         return true;
     } else if (settings["Main Story"] && current.Obj == 698 && old.Obj == 692)
     {
-        vars.completedsplits.insert(0, "River Pass I");
+        vars.completedsplits.Add("River Pass I");
         return true;
     } else if (settings["Main Story"] && current.Obj == 734 && old.Obj == 3701)
     {
-        vars.completedsplits.insert(0, "Alfheim Story");
+        vars.completedsplits.Add("Alfheim Story");
         return true;
     } else if (settings["Main Story"] && current.Obj == 40077 && old.Obj == 736)
     {
-        vars.completedsplits.insert(0, "Alfheim I");
+        vars.completedsplits.Add("Alfheim I");
         return true;
     } else if (settings["Main Story"] && current.Obj == 756 && old.Obj == 43039)
     {
-        vars.completedsplits.insert(0, "Boy is a god!");
+        vars.completedsplits.Add("Boy is a god!");
         return true;
     } else if (settings["Main Story"] && current.Obj == 1416 && old.Obj == 760)
     {
-        vars.completedsplits.insert(0, "Tyr's Vault Puzzles");
+        vars.completedsplits.Add("Tyr's Vault Puzzles");
         return true;
     } else if (settings["Main Story"] && current.Obj == 43063 && old.Obj == 1416)
     {
-        vars.completedsplits.insert(0, "Grendel Twins Fight");
+        vars.completedsplits.Add("Grendel Twins Fight");
         return true;
     }else if (settings["Main Story"] && current.Obj == 21391 && old.Obj == 3574)
     {
-        vars.completedsplits.insert(0, "Into the Giant Snake");
+        vars.completedsplits.Add("Into the Giant Snake");
         return true;
     } else if (settings["Main Story"] && current.Obj == 19891 && old.Obj == 19884)
     {
-        vars.completedsplits.insert(0, "Finish");
+        vars.completedsplits.Add("Finish");
         return true;
     }
 }


### PR DESCRIPTION
stuff i added & tested:
-changed insert with contains sense insert isint valid
-added a protection for valk splits to prevent double splitting when reloading checkpoint after picking up the helmet
-added a special split logic for the last valk in 100% ng+ so it doesnt double split by accident from the labor being completed
-removed buri stronghold as one of the split spots for location due to it splitting a lot sense u leave buri and go back to it twice in the same instance will readd in next pull request
-updated the tooltip for locations so its not as long
-Added all the new stuff above ive been cooking without removing all the new stuff Dobridp added in his last update

Future updates when tested:
-Xml file where all the settings can stay instead of haveing it all in the asl file and taking up several lines
-With the xml thing im deciding to do same thing i have for tomb raider autospliiter. TLDR to put it simply without frying peoples brains. I would make it where instead of needing 500 splits so it splits on every single obj change the player chooses which obj's it will split on. Along with updated split logic for main story splits
-NG 100% support eventually abt to go crazy with that one ngl
-even more trackers for 100% to prevent u kinda of missing stuff but eh might not add might just keep for myself